### PR TITLE
fix: capitalize changelog

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
   "manifest": "https://github.com/scari08/pf2e-chances/releases/latest/download/module.json",
   "download": "https://github.com/scari08/pf2e-chances/releases/download/1.2.2/module.zip",
   "readme": "https://github.com/scari08/pf2e-chances/blob/master/README.md",
-  "changelog": "https://github.com/scari08/pf2e-chances/blob/master/Changelog.md",
+  "changelog": "https://github.com/scari08/pf2e-chances/blob/master/CHANGELOG.md",
   "bugs": "https://github.com/scari08/pf2e-chances/issues",
   "relationships": {
     "systems": [


### PR DESCRIPTION
Modules such as Module Management+ and The Forge use this to link to your changelogs but the current link is a 404.